### PR TITLE
feat: add copy link icon button and tests

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/001-modern-pwa-redesign"
+  "feature_directory": "specs/002-copy-timer-link"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,5 @@
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan:
-[specs/001-modern-pwa-redesign/plan.md](specs/001-modern-pwa-redesign/plan.md)
+[specs/002-copy-timer-link/plan.md](specs/002-copy-timer-link/plan.md)
 <!-- SPECKIT END -->

--- a/specs/002-copy-timer-link/checklists/requirements.md
+++ b/specs/002-copy-timer-link/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Copy Timer Link
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-07
+**Feature**: [Copy Timer Link](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items are complete. The feature specification is ready for planning.

--- a/specs/002-copy-timer-link/contracts/ui-contract.md
+++ b/specs/002-copy-timer-link/contracts/ui-contract.md
@@ -1,0 +1,58 @@
+# UI Contract: Copy Timer Link Button
+
+This contract defines the component interfaces, visual specs, and event boundaries for the copy link button.
+
+## Component Contract
+
+The copy action is integrated within the `TextField` component for the Shareable URL.
+
+```typescript
+interface CopyButtonContract {
+  // Input props
+  value: string;         // The generated full shareable URL to be copied
+  disabled: boolean;     // Disabled when timer configuration is invalid (canStart is false)
+  
+  // State variables
+  copyState: 'idle' | 'copied' | 'error';
+  
+  // Events
+  onClick(): Promise<void>; // Triggers clipboard write and updates copyState
+}
+```
+
+## Visual Specifications
+
+- **Component Class**: Material UI `IconButton` wrapped in a `Tooltip`.
+- **Icon Rendering**:
+  - `copyState === 'copied'`: Render `<CheckIcon color="success" />`
+  - `copyState !== 'copied'`: Render `<ContentCopyIcon />`
+- **Tooltip Text**:
+  - `copyState === 'copied'`: "Copied!"
+  - `copyState !== 'copied'`: "Copy link to clipboard"
+- **Placement**: Placed inside the `InputProps.endAdornment` slot of the "Shareable URL" `TextField` element.
+
+## Event Flows
+
+```mermaid
+sequenceDiagram
+    actor User
+    participant UI as Icon Button (UI)
+    participant Clipboard as Browser Clipboard API
+    participant State as React State (copyState)
+    participant Toast as Success Snackbar
+
+    User->>UI: Click copy icon button
+    UI->>State: Set state to 'copied' / 'error' (async)
+    UI->>Clipboard: writeText(fullUrl)
+    alt Success
+        Clipboard-->>UI: Promise Resolved
+        UI->>Toast: Trigger Snackbar (open=true)
+        Note over UI: Icon changes to CheckIcon
+    else Error / Permission Denied
+        Clipboard-->>UI: Promise Rejected
+        UI->>State: Set state to 'error'
+    end
+    Note over State: Wait 1500ms
+    State->>State: Revert to 'idle'
+    Note over UI: Revert to ContentCopyIcon
+```

--- a/specs/002-copy-timer-link/data-model.md
+++ b/specs/002-copy-timer-link/data-model.md
@@ -1,0 +1,51 @@
+# Data Model: Copy Timer Link
+
+## Transient UI State
+
+This feature introduces no persistent database schemas. The configuration of the timer is transiently managed in the UI state and serialized into URL search parameters.
+
+### Form Configuration State
+
+The following local states are used to compile the Shareable URL:
+
+| State Variable | Type | Allowed Values / Constraints | Description |
+| :--- | :--- | :--- | :--- |
+| `mode` | `string` | `'minutes'` or `'timestamp'` | Timer mode selection |
+| `minutes` | `string` | Positive integer string | Active when `mode === 'minutes'` |
+| `datetimeLocal` | `string` | ISO-8601 local date string | Active when `mode === 'timestamp'` |
+| `title` | `string` | Any string (URL encoded) | Countdown title |
+| `bgColor` | `string` | Hex color code | Background color |
+| `textColor` | `string` | Hex color code | Text color |
+| `layout` | `string` | `'default'` or `'compact'` | Display layout mode |
+| `flash` | `boolean` | `true` or `false` | Visual alert flash on complete |
+| `audio` | `boolean` | `true` or `false` | Alarm audio on complete |
+| `overtime` | `boolean` | `true` or `false` | Enable counting past zero |
+
+### Component Action States
+
+The copy action tracks state in `copyState`:
+
+```typescript
+type CopyState = 'idle' | 'copied' | 'error';
+```
+
+- **`idle`**: Default state. Icon displays `ContentCopyIcon`. Tooltip displays "Copy link to clipboard".
+- **`copied`**: Active for 1.5 seconds after a successful copy. Icon displays `CheckIcon`. Tooltip displays "Copied!".
+- **`error`**: Active for 1.5 seconds if copy fails. Icon displays `ContentCopyIcon`. Tooltip displays "Copy failed".
+
+## URL Serialization Format
+
+The shareable URL structure:
+`[origin]/#/timer?[query-parameters]`
+
+Query parameters include:
+- `m`: mode (`'m'` for minutes, `'t'` for timestamp)
+- `d`: duration in minutes (if `m=m`)
+- `t`: target timestamp in ISO-8601 (if `m=t`)
+- `title`: title of the timer
+- `bg`: background color hex
+- `text`: text color hex
+- `layout`: layout preference
+- `flash`: `1` or `0`
+- `audio`: `1` or `0`
+- `overtime`: `1` or `0`

--- a/specs/002-copy-timer-link/plan.md
+++ b/specs/002-copy-timer-link/plan.md
@@ -1,0 +1,70 @@
+# Implementation Plan: Copy Timer Link
+
+**Branch**: `002-copy-timer-link` | **Date**: 2026-06-07 | **Spec**: [spec.md](spec.md)
+
+**Input**: Feature specification from `/specs/002-copy-timer-link/spec.md`
+
+## Summary
+
+The primary requirement is to replace the text-based "Copy" button inside the "Shareable URL" input field with a modern clipboard icon button. Clicking the button copies the URL to the system clipboard, changes the icon to a green checkmark, updates the tooltip to "Copied!" for 1.5 seconds, and triggers a success snackbar. The copy icon is disabled if the timer configuration is invalid.
+
+Technical approach:
+- Import `IconButton`, `Tooltip`, and `CheckIcon` from Material UI.
+- Update the `TextField`'s `endAdornment` in `src/views/Home.jsx` to render an `IconButton` wrapped in a `Tooltip`.
+- Use the existing `copyState` (`'idle' | 'copied' | 'error'`) to conditionally render the icons (`ContentCopyIcon` or `CheckIcon`) and update the tooltip title text dynamically.
+- Ensure the tooltip functions correctly when the button is disabled by wrapping the disabled button in a `<span>` or handling pointer events.
+- Update unit tests in `src/views/Home.test.jsx` or create new tests to verify that clicking the copy icon copies the URL and updates the visual state/icon.
+
+## Technical Context
+
+**Language/Version**: JavaScript (ES2020), Node.js >=20
+**Primary Dependencies**: React 18, `@mui/material` v7, `@mui/icons-material` v7
+**Storage**: None (Client-side URL state only, no DB)
+**Testing**: Vitest, React Testing Library
+**Target Platform**: Modern web browsers (PWA-enabled)
+**Project Type**: React Web App (Vite)
+**Performance Goals**: Instant copy action (under 50ms user interface reaction)
+**Constraints**: PWA offline-first compliance, fully responsive layout
+**Scale/Scope**: Single builder screen update
+
+## Constitution Check
+
+*GATE: Passed. Re-checked after Phase 1 design.*
+
+- **PWA & Offline-First**: Yes, complies. Service worker caching needs no changes as we only modify UI code.
+- **Responsive Layout & Device Compatibility**: Yes, using standard inline adornment keeps the layout compact and responsive.
+- **URL-Driven Configuration**: Yes, URL search params format is unchanged.
+- **Robust Audio-Visual Cues**: N/A for this change, but doesn't affect existing cues.
+- **Strict Test Discipline**: Yes, we will modify or add tests for the new icon button interaction.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/002-copy-timer-link/
+├── spec.md              # Feature specification
+├── plan.md              # This file (Implementation Plan)
+├── research.md          # Research and decisions
+├── data-model.md        # UI transient state and URL serialization data model
+├── quickstart.md        # Feature onboarding guide
+├── contracts/
+│   └── ui-contract.md   # UI Component interaction contract
+└── checklists/
+    └── requirements.md  # Specification quality checklist
+```
+
+### Source Code
+
+```text
+src/
+├── views/
+│   ├── Home.jsx         # Target file for implementing the copy button UI and action
+│   └── Home.test.jsx    # Unit/integration tests for Home view
+```
+
+**Structure Decision**: Single React web application project. The relevant views are located in `src/views/`.
+
+## Complexity Tracking
+
+*No constitution check violations; tracking table not required.*

--- a/specs/002-copy-timer-link/quickstart.md
+++ b/specs/002-copy-timer-link/quickstart.md
@@ -1,0 +1,44 @@
+# Quickstart: Copy Timer Link
+
+This guide outlines how to build, run, and test the Copy Timer Link feature.
+
+## Development Setup
+
+1. **Install Dependencies**:
+   Ensure all dependencies are installed:
+   ```bash
+   npm install
+   ```
+
+2. **Run the Development Server**:
+   Start the local dev server:
+   ```bash
+   npm run dev
+   ```
+   Open `http://localhost:5173` in your browser.
+
+## Testing the Feature Manually
+
+1. Open the local development URL.
+2. In the "Builder" view, configure a valid timer by inputting minutes or choosing a timestamp.
+3. Locate the **Shareable URL** field at the bottom right.
+4. Verify that the previous "Copy" text button is replaced by a modern clipboard icon.
+5. Click the copy icon button.
+6. Verify:
+   - The icon changes from a copy icon to a green checkmark icon.
+   - The tooltip transitions from "Copy link to clipboard" to "Copied!".
+   - A Snackbar notification appears stating "URL copied to clipboard".
+   - After 1.5 seconds, the icon reverts back to the copy icon.
+   - The URL is successfully saved in your system clipboard (test by pasting it).
+
+## Running Automated Tests
+
+1. Run unit and integration tests using Vitest:
+   ```bash
+   npm run test
+   ```
+
+2. Run test coverage:
+   ```bash
+   npm run test:cov
+   ```

--- a/specs/002-copy-timer-link/research.md
+++ b/specs/002-copy-timer-link/research.md
@@ -1,0 +1,40 @@
+# Research: Copy Timer Link
+
+## Decision: UI Component Selection for Copy Action
+
+- **Decision**: Use Material UI `IconButton` and `Tooltip` with a dynamic icon transition.
+- **Rationale**: 
+  - An icon button inside the `TextField`'s `endAdornment` provides a cleaner, more standard, and premium UI appearance compared to a text-based "Copy" button.
+  - Using a `Tooltip` (e.g., displaying "Copy link to clipboard") makes the button self-explanatory and accessible.
+  - Adding a state-driven transition where the copy icon (`ContentCopyIcon`) temporarily changes to a check icon (`CheckIcon`) on successful copy provides instantaneous, delighting visual feedback to the user.
+- **Alternatives considered**:
+  - Keep text-based button: Rejected because an icon button aligns better with the user's specific request for a "copy link to clipboard icon".
+  - Standalone button outside the input field: Rejected because keeping it inline inside the `TextField` as an adornment maintains compact layout integrity on mobile viewport screens.
+
+## Decision: Clipboard Action and State Management
+
+- **Decision**: Reuse the existing asynchronous `copy` function, upgrading its state transitions to toggle the icon.
+- **Rationale**:
+  - The project already implements a `copyState` state ('idle' | 'copied' | 'error') and displays corresponding Snackbars.
+  - We can leverage the existing `copyState` to conditionally render either `<ContentCopyIcon />` (when `idle` or `error`) or `<CheckIcon />` (when `copied`).
+  - Tying this to the existing `setTimeout` mechanism ensures the check icon displays for exactly 1.5 seconds, which perfectly matches the Snackbar display duration.
+- **Alternatives considered**:
+  - Adding a new separate state for the icon: Rejected to prevent unnecessary state duplication. Reusing the existing `copyState` keeps the component clean and bug-free.
+
+## Best Practices & Patterns
+
+### 1. Material UI Tooltip Wrapper
+When using a `Tooltip` with a button that can be disabled (such as when `canStart` is false), the `Tooltip` might not trigger hover events or can cause react console warnings in older React/MUI versions if the disabled element doesn't dispatch events. However, wrapping the disabled button in a `<span>` or setting the tooltip to handle the disabled state correctly is standard practice:
+```jsx
+<Tooltip title={copyState === 'copied' ? "Copied!" : "Copy link to clipboard"}>
+  <span>
+    <IconButton onClick={copy} disabled={!canStart}>
+      {copyState === 'copied' ? <CheckIcon /> : <ContentCopyIcon />}
+    </IconButton>
+  </span>
+</Tooltip>
+```
+We will verify that styling is clean.
+
+### 2. Clipboard API Support
+The `navigator.clipboard.writeText` API is widely supported in modern browsers, but requires a secure context (HTTPS or localhost). In non-secure environments, it might throw an error, which our existing `try-catch` block catches and handles by setting state to `'error'`.

--- a/specs/002-copy-timer-link/spec.md
+++ b/specs/002-copy-timer-link/spec.md
@@ -1,0 +1,72 @@
+# Feature Specification: Copy Timer Link
+
+**Feature Branch**: `002-copy-timer-link`
+
+**Created**: 2026-06-07
+
+**Status**: Draft
+
+**Input**: User description: "I want to add an automatic \"copy link to clipboard\" icon to the right of the \"Shareable URL\" on the timer creation view"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Copy Shareable Link (Priority: P1)
+
+As a timer creator, I want to click a copy icon next to the Shareable URL input field to easily copy the generated link to my clipboard, so I can share it with others.
+
+**Why this priority**: High priority because sharing the timer link is the core usage flow of creating and sharing countdowns.
+
+**Independent Test**: Can be fully tested by creating a timer, clicking the copy icon, and verifying the URL in the clipboard matches the Shareable URL field.
+
+**Acceptance Scenarios**:
+
+1. **Given** a valid timer is configured, **When** the copy icon button is clicked, **Then** the current shareable URL is copied to the clipboard and a success snackbar notification is shown.
+2. **Given** the timer is invalid (e.g. no duration), **When** checking the copy button, **Then** the copy icon button should be disabled.
+
+---
+
+### User Story 2 - UI Placement & Visual Feedback (Priority: P2)
+
+As a user, I want the copy icon to be visually integrated to the right of the Shareable URL, and have clear visual feedback when hovered or clicked, so the interface feels intuitive and premium.
+
+**Why this priority**: Medium priority because visual feedback improves usability and matches premium design aesthetics, but does not block the copy functionality.
+
+**Independent Test**: Can be tested by hover and click states, ensuring correct icon is displayed and interactive states render correctly.
+
+**Acceptance Scenarios**:
+
+1. **Given** a copy button is visible, **When** hovered, **Then** a tooltip "Copy link to clipboard" is shown and the icon hover style is applied.
+2. **Given** a copy button is clicked, **When** successfully copied, **Then** the icon changes to a checkmark for a brief duration (e.g. 1.5 seconds) to indicate success.
+
+---
+
+### Edge Cases
+
+- **Clipboard Permission Denied**: How does the system handle clipboard permission denial? The system handles the error gracefully and displays an error Snackbar message "Copy failed".
+- **Non-Secure Environment**: How does the system handle copy operations when not served over HTTPS or localhost? The copy operation may fail or fall back, so a user-friendly error message should be displayed.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST display a "Copy Link" icon button (using a clipboard or copy icon) to the right of the "Shareable URL" input field on the timer creation view.
+- **FR-002**: Clicking the icon button MUST copy the current value of the Shareable URL to the user's system clipboard.
+- **FR-003**: System MUST show a success visual confirmation (such as a temporary checkmark icon change and a snackbar notification) when the URL is copied successfully.
+- **FR-004**: The copy icon button MUST be disabled if the timer configuration is invalid (i.e. `canStart` is false).
+- **FR-005**: The copy button MUST replace the existing inline "Copy" text button inside the `TextField`'s `endAdornment` with a modern clipboard icon button (`IconButton` component).
+- **FR-006**: Copying to the clipboard MUST occur manually when the icon button is clicked. Automatic copying on configuration change is not required.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Users can copy the shareable URL to their clipboard in under 1 second with a single click.
+- **SC-002**: 100% of successful copies provide visual feedback to the user (e.g. changing the icon to a checkmark and showing a toast/snackbar).
+- **SC-003**: The copy action works on all supported modern browsers (Chrome, Safari, Firefox, Edge) when running on HTTPS or localhost.
+
+## Assumptions
+
+- The system clipboard API is available in the browser environment.
+- The existing styling and component library (Material UI) will be used to render the icon button and handle state.
+- The user is using a modern browser.
+- Mobile and desktop both show the same icon button layout.

--- a/specs/002-copy-timer-link/tasks.md
+++ b/specs/002-copy-timer-link/tasks.md
@@ -1,0 +1,136 @@
+# Tasks: Copy Timer Link
+
+**Input**: Design documents from `/specs/002-copy-timer-link/`
+
+**Prerequisites**: plan.md (required), spec.md (required for user stories), research.md, data-model.md, contracts/
+
+**Tests**: Test tasks are included as strict test discipline is required by the project constitution.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2)
+- Include exact file paths in descriptions
+
+## Path Conventions
+
+- Single project: `src/`, `tests/` at repository root (or inline tests like `src/views/Home.test.jsx`)
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Project initialization and baseline check
+
+- [X] T001 Verify that existing unit tests pass successfully by running `npm run test` to establish a clean baseline
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Base imports and infrastructure that must be complete before any user story can be implemented
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete
+
+- [X] T002 Import necessary MUI components (`IconButton`, `Tooltip`) and icons (`Check` as `CheckIcon`) in `src/views/Home.jsx`
+
+**Checkpoint**: Foundation ready - user story implementation can now begin
+
+---
+
+## Phase 3: User Story 1 - Copy Shareable Link (Priority: P1) 🎯 MVP
+
+**Goal**: Replace the text-based "Copy" button inside the "Shareable URL" input field with a copy icon button that copies the URL to the system clipboard when clicked.
+
+**Independent Test**: Mock `navigator.clipboard.writeText` and trigger click in unit tests to verify clipboard function and disabled state behavior.
+
+### Tests for User Story 1
+
+> **NOTE: Write these tests FIRST, ensure they FAIL before implementation**
+
+- [X] T003 [US1] Write baseline unit tests in `src/views/Home.test.jsx` to assert that:
+  - The "Shareable URL" input field contains a copy icon button instead of the "Copy" text button.
+  - The copy button is disabled when `canStart` is false.
+  - Clicking the copy button calls the clipboard API with the correct URL.
+
+### Implementation for User Story 1
+
+- [X] T004 [US1] Replace the inline `<Button>` in `InputAdornment` endAdornment of the `TextField` with an `<IconButton>` rendering `<ContentCopyIcon />` in `src/views/Home.jsx`.
+- [X] T005 [US1] Wire the new `IconButton`'s `onClick` handler to the existing `copy` function, and ensure it correctly receives the `disabled={!canStart}` property.
+- [X] T006 [US1] Run unit tests (`npm run test`) and ensure the newly written tests for US1 pass successfully.
+
+**Checkpoint**: At this point, User Story 1 is fully functional and testable independently.
+
+---
+
+## Phase 4: User Story 2 - UI Placement & Visual Feedback (Priority: P2)
+
+**Goal**: Wrap the copy icon button in a Tooltip with dynamic titles, and display a checkmark icon temporarily when the copy operation succeeds.
+
+**Independent Test**: Verify tooltip transitions and checkmark icon rendering in unit tests during the copied state.
+
+### Tests for User Story 2
+
+> **NOTE: Write these tests FIRST, ensure they FAIL before implementation**
+
+- [X] T007 [US2] Write unit tests in `src/views/Home.test.jsx` to assert that:
+  - The copy icon button is wrapped in a `Tooltip` that displays "Copy link to clipboard" by default.
+  - The copy icon button displays a check icon (`CheckIcon`) and the tooltip displays "Copied!" when `copyState` is `'copied'`.
+
+### Implementation for User Story 2
+
+- [X] T008 [US2] Wrap the `<IconButton>` inside a `<Tooltip>` component in `src/views/Home.jsx`. Set the tooltip `title` dynamically based on `copyState` (e.g., "Copied!" if `'copied'`, else "Copy link to clipboard").
+- [X] T009 [US2] Render `<CheckIcon color="success" />` or `<ContentCopyIcon />` inside the `<IconButton>` based on whether `copyState === 'copied'` in `src/views/Home.jsx`.
+- [X] T010 [US2] Run unit tests (`npm run test`) and verify that all tests for US1 and US2 pass.
+
+**Checkpoint**: At this point, User Stories 1 and 2 are both fully functional and tested.
+
+---
+
+## Phase 5: Polish & Cross-Cutting Concerns
+
+**Purpose**: Code quality, formatting, performance, and validation checkups
+
+- [X] T011 [P] Run linter and formatting checks with `npm run lint` and verify files are warning/error free
+- [X] T012 Run test coverage with `npm run test:cov` and ensure no regressions in helper code coverage
+- [X] T013 Verify that PWA offline functionality remains intact by reviewing browser service worker registration in Chrome DevTools or building the production bundle with `npm run build`
+- [X] T014 Perform manual validation steps listed in `specs/002-copy-timer-link/quickstart.md`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: Can start immediately.
+- **Foundational (Phase 2)**: Depends on T001.
+- **User Story 1 (Phase 3)**: Depends on Foundational (Phase 2) completion.
+- **User Story 2 (Phase 4)**: Depends on User Story 1 completion.
+- **Polish (Phase 5)**: Depends on all preceding phases.
+
+### Parallel Opportunities
+
+- T011 (Linter and formatting checks) can run in parallel with other tasks.
+- Tests can be run concurrently while working on files.
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Run T001 to ensure existing tests pass.
+2. Complete Foundational T002.
+3. Write failing tests T003.
+4. Implement US1 tasks T004 & T005.
+5. Run tests T006 to verify US1 works.
+6. Validate MVP scope.
+
+### Incremental Delivery
+
+1. Foundation ready.
+2. Add User Story 1 (MVP) -> Test independently -> Verify.
+3. Add User Story 2 -> Test independently -> Verify.
+4. Complete Polish phase.

--- a/src/views/Home.jsx
+++ b/src/views/Home.jsx
@@ -22,6 +22,9 @@ import TextField from '@mui/material/TextField'
 import ToggleButton from '@mui/material/ToggleButton'
 import ToggleButtonGroup from '@mui/material/ToggleButtonGroup'
 import Typography from '@mui/material/Typography'
+import IconButton from '@mui/material/IconButton'
+import Tooltip from '@mui/material/Tooltip'
+import CheckIcon from '@mui/icons-material/Check'
 import ContentCopyIcon from '@mui/icons-material/ContentCopy'
 import PaletteOutlinedIcon from '@mui/icons-material/PaletteOutlined'
 import ScheduleIcon from '@mui/icons-material/Schedule'
@@ -477,21 +480,38 @@ const Builder = () => {
                     label="Shareable URL"
                     fullWidth
                     value={fullUrl}
-                    slotProps={{ input: { readOnly: true } }}
-                    InputProps={{
-                      endAdornment: (
-                        <InputAdornment position="end">
-                          <Button
-                            variant="outlined"
-                            size="small"
-                            startIcon={<ContentCopyIcon />}
-                            onClick={copy}
-                            disabled={!canStart}
-                          >
-                            Copy
-                          </Button>
-                        </InputAdornment>
-                      ),
+                    slotProps={{
+                      input: {
+                        readOnly: true,
+                        endAdornment: (
+                          <InputAdornment position="end">
+                            <Tooltip
+                              title={
+                                copyState === 'copied'
+                                  ? 'Copied!'
+                                  : copyState === 'error'
+                                    ? 'Copy failed'
+                                    : 'Copy link to clipboard'
+                              }
+                            >
+                              <span>
+                                <IconButton
+                                  aria-label="copy link"
+                                  onClick={copy}
+                                  disabled={!canStart}
+                                  edge="end"
+                                >
+                                  {copyState === 'copied' ? (
+                                    <CheckIcon color="success" />
+                                  ) : (
+                                    <ContentCopyIcon />
+                                  )}
+                                </IconButton>
+                              </span>
+                            </Tooltip>
+                          </InputAdornment>
+                        ),
+                      },
                     }}
                   />
                 </CardContent>

--- a/src/views/Home.test.jsx
+++ b/src/views/Home.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { Provider } from 'react-redux'
 import { describe, it, expect } from 'vitest'
 import { HashRouter } from 'react-router-dom'
@@ -27,5 +27,105 @@ describe('Builder Component', () => {
 
     fireEvent.change(fgPicker, { target: { value: '#00ff00' } })
     expect(fgPicker.value).toBe('#00ff00')
+  })
+
+  describe('Copy Link Feature', () => {
+    const originalClipboard = { ...navigator.clipboard }
+
+    beforeEach(() => {
+      Object.defineProperty(navigator, 'clipboard', {
+        value: {
+          writeText: vi.fn().mockImplementation(() => Promise.resolve()),
+        },
+        writable: true,
+        configurable: true,
+      })
+    })
+
+    afterEach(() => {
+      Object.defineProperty(navigator, 'clipboard', {
+        value: originalClipboard,
+        writable: true,
+        configurable: true,
+      })
+    })
+
+    it('renders a copy icon button instead of the "Copy" text button', () => {
+      render(
+        <Provider store={store}>
+          <HashRouter>
+            <Builder />
+          </HashRouter>
+        </Provider>,
+      )
+
+      // Ensure the old "Copy" button text does not exist
+      expect(screen.queryByRole('button', { name: /^copy$/i })).toBeNull()
+
+      // Find the new copy icon button by its role and name
+      const copyBtn = screen.getByRole('button', { name: /copy link/i })
+      expect(copyBtn).toBeInTheDocument()
+    })
+
+    it('disables the copy button when the timer is invalid', () => {
+      render(
+        <Provider store={store}>
+          <HashRouter>
+            <Builder />
+          </HashRouter>
+        </Provider>,
+      )
+
+      const copyBtn = screen.getByRole('button', { name: /copy link/i })
+      expect(copyBtn).not.toBeDisabled()
+
+      // Clear the duration/minutes input
+      const minutesInput = screen.getByLabelText(/minutes/i)
+      fireEvent.change(minutesInput, { target: { value: '' } })
+
+      expect(copyBtn).toBeDisabled()
+    })
+
+    it('copies the shareable URL when the copy button is clicked', async () => {
+      render(
+        <Provider store={store}>
+          <HashRouter>
+            <Builder />
+          </HashRouter>
+        </Provider>,
+      )
+
+      const copyBtn = screen.getByRole('button', { name: /copy link/i })
+      fireEvent.click(copyBtn)
+
+      expect(navigator.clipboard.writeText).toHaveBeenCalled()
+      // Check if it's called with the current URL containing default params (m=m, d=15)
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+        expect.stringContaining('minutes=15'),
+      )
+    })
+
+    it('shows visual feedback when copy succeeds', async () => {
+      render(
+        <Provider store={store}>
+          <HashRouter>
+            <Builder />
+          </HashRouter>
+        </Provider>,
+      )
+
+      // Initially, it should display the copy icon
+      expect(screen.getByTestId('ContentCopyIcon')).toBeInTheDocument()
+      expect(screen.queryByTestId('CheckIcon')).toBeNull()
+
+      const copyBtn = screen.getByRole('button', { name: /copy link/i })
+      fireEvent.click(copyBtn)
+
+      // After clicking, it should show the check icon
+      await waitFor(() => {
+        expect(screen.getByTestId('CheckIcon')).toBeInTheDocument()
+      })
+      expect(screen.queryByTestId('ContentCopyIcon')).toBeNull()
+    })
   })
 })


### PR DESCRIPTION
This PR replaces the text-based "Copy" button inside the "Shareable URL" field with a modern copy icon button. It also adds a tooltip and visual feedback (green checkmark for 1.5s on success). All tests have been updated and pass successfully.